### PR TITLE
Add mock and tests assertions for notifications

### DIFF
--- a/src/masonite/notifications/AnonymousNotifiable.py
+++ b/src/masonite/notifications/AnonymousNotifiable.py
@@ -1,6 +1,6 @@
 """Anonymous Notifiable mixin"""
 
-from .Notification import Notification as NotificationService
+from .Notification import Notification
 from .Notifiable import Notifiable
 
 
@@ -31,4 +31,4 @@ class AnonymousNotifiable(Notifiable):
     def notify(self, notification, dry=False, fail_silently=False):
         """Send the given notification."""
         from wsgi import container
-        return NotificationService(container).send(self, notification, self._routes, dry, fail_silently)
+        container.make("Notification").send(self, notification, self._routes, dry, fail_silently)

--- a/src/masonite/notifications/Mockable.py
+++ b/src/masonite/notifications/Mockable.py
@@ -1,0 +1,32 @@
+from abc import abstractmethod
+
+class StaticallyCallable(type):
+    def __getattr__(self, attribute, *args, **kwargs):
+        from wsgi import container
+        instance = container.make(self.__service__)
+        return getattr(instance, attribute)
+
+
+class MockableService(object, metaclass=StaticallyCallable):
+
+    __service__ = ""
+
+    @abstractmethod
+    def get_mock_class():
+        raise NotImplementedError(
+            "get_mock_class() method must be implemented for a mockable service."
+        )
+
+    @classmethod
+    def fake(cls):
+        from wsgi import container
+        mock_instance = cls.get_mock_class()(container)
+        container.bind(cls.__service__, mock_instance)
+        return mock_instance
+
+    @classmethod
+    def restore(cls):
+        from wsgi import container
+        original_instance = cls(container)
+        container.bind(cls.__service__, original_instance)
+        return original_instance

--- a/src/masonite/notifications/Notifiable.py
+++ b/src/masonite/notifications/Notifiable.py
@@ -2,7 +2,6 @@
 from masoniteorm.relationships import has_many
 
 from .models.DatabaseNotification import DatabaseNotification
-from .Notification import Notification as NotificationService
 from .exceptions import NotificationRouteNotImplemented
 
 
@@ -10,8 +9,7 @@ class Notifiable(object):
     def notify(self, notification, channels=[], dry=False, fail_silently=False):
         """Send the given notification."""
         from wsgi import container
-
-        return NotificationService(container).send(self, notification, channels, dry, fail_silently)
+        return container.make("Notification").send(self, notification, channels, dry, fail_silently)
 
     def route_notification_for(self, channel, notification=None):
         """Get the notification routing information for the given channel."""

--- a/src/masonite/notifications/Notification.py
+++ b/src/masonite/notifications/Notification.py
@@ -7,13 +7,19 @@ from masoniteorm.models import Model
 
 from .NotificationContract import NotificationContract
 from .exceptions import InvalidNotificationType, NotificationChannelsNotDefined
+from .Mockable import MockableService
 
 
-class Notification(object):
+class Notification(MockableService):
     """Notification handler which handle sending/queuing notifications anonymously
     or to notifiables through different channels."""
 
-    called_notifications = []
+    __service__ = "Notification"
+
+    @classmethod
+    def get_mock_class(cls):
+        from .NotificationTester import NotificationTester
+        return NotificationTester
 
     def __init__(self, container: App):
         """Notification constructor.
@@ -131,8 +137,29 @@ class Notification(object):
 
         return _channels
 
-    def route(self, channel, route):
+    # def route(self, channel, route):
+    #     """Begin sending a notification to an anonymous notifiable."""
+    #     from .AnonymousNotifiable import AnonymousNotifiable
+
+    #     return AnonymousNotifiable().route(channel, route)
+    @staticmethod
+    def route(channel, route):
         """Begin sending a notification to an anonymous notifiable."""
         from .AnonymousNotifiable import AnonymousNotifiable
 
         return AnonymousNotifiable().route(channel, route)
+
+    # @classmethod
+    # def fake(cls):
+    #     from .NotificationTester import NotificationTester
+    #     from wsgi import container
+
+    #     tester = NotificationTester(container)
+    #     container.bind("Notification", tester)
+    #     return tester
+
+    # @classmethod
+    # def restore(cls):
+    #     from wsgi import container
+
+    #     return container.bind("Notification", cls(container))

--- a/src/masonite/notifications/NotificationTester.py
+++ b/src/masonite/notifications/NotificationTester.py
@@ -1,0 +1,101 @@
+from functools import reduce
+import collections
+
+
+from .Notification import Notification
+from .Notifiable import Notifiable
+from .AnonymousNotifiable import AnonymousNotifiable
+
+
+def deep_get(dictionary, keys, default=None):
+    return reduce(lambda d, key: d.get(key, default) if isinstance(d, dict) else default, keys.split("."), dictionary)
+
+
+def makehash():
+    return collections.defaultdict(makehash)
+
+
+class NotificationTester(Notification):
+
+    def __init__(self, container):
+        super().__init__(container)
+        self.notifications = makehash()
+
+    def send_or_queue(
+        self,
+        notifiable,
+        notification,
+        notification_id,
+        channel_instance,
+        dry=False,
+        fail_silently=False,
+    ):
+        """Fake sending notifications by saving instead in a a specific structure allowing
+        to make different assertions on it later."""
+        if not notification.id:
+            notification.id = notification_id
+        data = {
+            "notification": notification,
+            "channels": channel_instance,
+            "notifiable": notifiable,
+            "dry": dry,
+            "fail_silently": fail_silently
+        }
+
+        if (isinstance(notifiable, AnonymousNotifiable)):
+            notifiable_id = list(notifiable._routes.values())[0]
+            # notifiable_channel = list(notifiable._routes.keys())[0]
+            path = f"__anonymous__.{notifiable_id}.{notification.__class__.__name__}"
+        else:
+            notifiable_id = notifiable.get_primary_key_value()
+            path = f"{notifiable.__class__.__name__}.{notifiable_id}.{notification.__class__.__name__}"
+
+        notifs = deep_get(self.notifications, path)
+        if notifs:
+            notifs.append(data)
+        else:
+            self.notifications[path.split(".")[0]][str(notifiable_id)][str(notification.__class__.__name__)] = [data]
+
+    def assertNothingSent(self):
+        """Assert no notifications has been sent since last call to Notifications.fake()."""
+        assert not self.notifications
+
+    def assertSentTo(self, notifiables, notification_class, test_method=None, count=1):
+        """
+            Assert a notification <notification_class> has been sent to the given notifiables once
+            or count times.
+            In addition assert that the notification is passing the given test if provided.
+
+            notifiables: user, [user1, user2], 'test@.email.com', '#general
+        """
+        if not isinstance(notifiables, list):
+            notifiables = [notifiables]
+        for notifiable in notifiables:
+            if (isinstance(notifiable, Notifiable)):
+                user_notifs = self.notifications[str(notifiable.__class__.__name__)][str(notifiable.get_primary_key_value())]
+            else:
+                notifiable_key = notifiable
+                user_notifs = self.notifications["__anonymous__"][notifiable_key]
+            # check that {count} notification of type {notification_class} have been sent
+            user_notifs_of_type = user_notifs.get(str(notification_class.__name__), [])
+            assert len(user_notifs_of_type) == count
+            # check that the first notification is passing the test
+            if test_method:
+                test_notification = user_notifs_of_type[0]
+                assert test_method(notifiable, test_notification["notification"], test_notification["channels"])
+
+    def notificationsFor(self, notifiable, notification_class=None):
+        if (isinstance(notifiable, Notifiable)):
+            try:
+                all_notifs = self.notifications[str(notifiable.__class__.__name__)][str(notifiable.get_primary_key_value())]
+            except KeyError:
+                return []
+        else:
+            try:
+                all_notifs = self.notifications["__anonymous__"][notifiable]
+            except KeyError:
+                return []
+        # filter by notification type
+        if notification_class:
+            all_notifs = all_notifs.get(str(notification_class.__name__), [])
+        return list(map(lambda obj: obj["notification"], all_notifs))

--- a/tests/test_faking_notifications.py
+++ b/tests/test_faking_notifications.py
@@ -1,0 +1,26 @@
+from tests.test_notify import WelcomeNotification
+from src.masonite.notifications.Notification import Notification
+from tests.UserTestCase import UserTestCase
+
+
+class TestFakingEntireTestSuite(UserTestCase):
+
+    def setUp(self):
+        super().setUp()
+        Notification.fake()
+
+    def tearDown(self):
+        super().tearDown()
+        Notification.restore()
+
+    def test_1(self):
+        Notification.assertNothingSent()
+        Notification.route("mail", "john.doe@masonite.com").notify(WelcomeNotification("John"))
+        Notification.assertSentTo("john.doe@masonite.com", WelcomeNotification)
+
+    def test_2(self):
+        Notification.assertNothingSent()
+        Notification.route("mail", "john.doe@masonite.com").notify(WelcomeNotification("Joe"))
+        Notification.assertSentTo("john.doe@masonite.com", WelcomeNotification,
+            lambda notifiable, notif, channels: notif.name == "Joe"
+        )


### PR DESCRIPTION
Here is how it can be used: (same idea than on main repo https://github.com/MasoniteFramework/masonite/pull/406)

```python
class TestFakingEntireTestSuite(UserTestCase):

    def setUp(self):
        super().setUp()
        Notification.fake()

    def tearDown(self):
        super().tearDown()
        Notification.restore()

    def test_1(self):
        Notification.assertNothingSent()
        Notification.route("mail", "john.doe@masonite.com").notify(WelcomeNotification("John"))
        Notification.assertSentTo("john.doe@masonite.com", WelcomeNotification)

    def test_2(self):
        Notification.assertNothingSent()
        Notification.route("mail", "john.doe@masonite.com").notify(WelcomeNotification("Joe"))
        Notification.assertSentTo("john.doe@masonite.com", WelcomeNotification,
            lambda notifiable, notif, channels: notif.name == "Joe"
        )
```